### PR TITLE
refactor: use the new colors/theme.lua

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,14 +41,9 @@ return M"
 }
 
 fn generate_vim_colors_file(name: &str) {
-    let vim_colors_file_data = format!(
-        "lua << EOF
-local {name} = require(\"{name}\")
-{name}.setup({{}})
-EOF"
-    );
+    let vim_colors_file_data = format!("require(\"{name}\").setup({{}})\n");
 
-    fs::write(format!("{name}/colors/{name}.vim",), vim_colors_file_data)
+    fs::write(format!("{name}/colors/{name}.lua",), vim_colors_file_data)
         .expect("problem creating palette file");
 }
 


### PR DESCRIPTION
Support for lua files in `colors/` has been available in neovim for a while now :smile:

Here's how it looks for `lunar.nvim`

```diff
diff --git a/colors/lunar.lua b/colors/lunar.lua
new file mode 100644
index 0000000..8d058c4
--- /dev/null
+++ b/colors/lunar.lua
@@ -0,0 +1 @@
+require("lunar").setup({})
diff --git a/colors/lunar.vim b/colors/lunar.vim
deleted file mode 100644
index f42aa34..0000000
--- a/colors/lunar.vim
+++ /dev/null
@@ -1,4 +0,0 @@
-lua << EOF
-local lunar = require("lunar")
-lunar.setup({})
-EOF
\ No newline at end of file
```
